### PR TITLE
Minor QoL fixes

### DIFF
--- a/src/AniEditor/AniEditorAddSprite.cpp
+++ b/src/AniEditor/AniEditorAddSprite.cpp
@@ -348,6 +348,7 @@ namespace TilesEditor
 
 
 						b.addButton("New Sprite Index", QMessageBox::ButtonRole::ActionRole);
+						b.addButton("Overwrite", QMessageBox::ButtonRole::AcceptRole);
 						b.addButton("Skip", QMessageBox::ButtonRole::RejectRole);
 
 
@@ -368,11 +369,19 @@ namespace TilesEditor
 					continue;
 				}
 
-				//New id
-				if (existsOption == QMessageBox::ButtonRole::ActionRole)
-					spriteIndex = m_editor->getAni().getNextSpriteIndex(true);
+			//New id
+			if (existsOption == QMessageBox::ButtonRole::ActionRole)
+				spriteIndex = m_editor->getAni().getNextSpriteIndex(true);
 
-				auto sprite = new Ani::AniSprite;
+			//Overwrite
+			if (existsOption == QMessageBox::ButtonRole::AcceptRole)
+			{
+				auto existingSprite = m_editor->getAni().getAniSprite(spriteIndex, "");
+				if (existingSprite)
+					new UndoCommandDeleteSprite(m_editor, existingSprite, m_resourceManager, undoCommand);
+			}
+
+			auto sprite = new Ani::AniSprite;
 				sprite->index = spriteIndex;
 
 				sprite->comment = count == 1 ? ui.commentLineEdit->text() :  QString("%1 (%2, %3)").arg(ui.commentLineEdit->text()).arg(column).arg(row);

--- a/src/EditorTabWidget.cpp
+++ b/src/EditorTabWidget.cpp
@@ -1835,17 +1835,24 @@ namespace TilesEditor
 				auto rect = m_tilesSelector.getSelection();
 				if (rect.intersects(QRectF(pos.x(), pos.y(), 1, 1)))
 				{
-					auto hcount = int(rect.width() / 16);
-					auto vcount = int(rect.height() / 16);
-					auto tileSelection = new TileSelection(-1000000, -1000000, hcount, vcount, m_selectedTilesLayer);
+				auto hcount = int(rect.width() / 16);
+				auto vcount = int(rect.height() / 16);
+				auto tileSelection = new TileSelection(-1000000, -1000000, hcount, vcount, m_selectedTilesLayer);
 
-					if(hcount == 1 && vcount == 1)
-						tileSelection->setDragOffset(tileSelection->getX(), tileSelection->getY(), !QGuiApplication::keyboardModifiers().testFlag(Qt::KeyboardModifier::ControlModifier), getSnapX(), getSnapY());
-					else tileSelection->setDragOffset(tileSelection->getX() + std::floor(pos.x() / getUnitWidth()) * getUnitWidth() - rect.x(), tileSelection->getY() + std::floor(pos.y() / getUnitHeight()) * getUnitHeight() - rect.y(), !QGuiApplication::keyboardModifiers().testFlag(Qt::KeyboardModifier::ControlModifier), getSnapX(), getSnapY());
-
+				if(hcount == 1 && vcount == 1)
+					tileSelection->setDragOffset(tileSelection->getX(), tileSelection->getY(), !QGuiApplication::keyboardModifiers().testFlag(Qt::KeyboardModifier::ControlModifier), getSnapX(), getSnapY());
+				else
+				{
+					auto clickTileX = int(std::floor(pos.x() / 16.0));
+					auto clickTileY = int(std::floor(pos.y() / 16.0));
+					auto rectTileX = int(std::floor(rect.x() / 16.0));
+					auto rectTileY = int(std::floor(rect.y() / 16.0));
+					auto offsetTileX = clickTileX - rectTileX;
+					auto offsetTileY = clickTileY - rectTileY;
+					tileSelection->setDragOffset(tileSelection->getX() + (offsetTileX * 16.0), tileSelection->getY() + (offsetTileY * 16.0), false, getSnapX(), getSnapY());
+				}
 					tileSelection->setApplyTranslucency(true);
 					tileSelection->setMouseDragButton(Qt::MouseButton::LeftButton);
-
 					for (int y = 0; y < vcount; ++y)
 					{
 						for (int x = 0; x < hcount; ++x)

--- a/src/Selector.h
+++ b/src/Selector.h
@@ -19,6 +19,9 @@ namespace TilesEditor
 
         qreal   m_snapX = 0.0,
             m_snapY = 0.0;
+            
+        int m_startTileX = 0,
+            m_startTileY = 0;
 
         bool    m_selecting = false;
         bool    m_visible = false;
@@ -42,27 +45,33 @@ namespace TilesEditor
         {
             m_snapX = snapX;
             m_snapY = snapY;
-
-
-            m_x1 = qFloor(x / snapX) * snapX;
-            m_y1 = qFloor(y / snapY) * snapY;
-
+            m_startTileX = qFloor(x / snapX);
+            m_startTileY = qFloor(y / snapY);
+            m_x1 = m_startTileX * snapX;
+            m_y1 = m_startTileY * snapY;
             m_x2 = m_x1 + snapX;
             m_y2 = m_y1 + snapY;
             m_selecting = true;
-
-
         }
 
         void updateSelection(float x, float y)
         {
-            if (x > m_x1)
-                m_x2 = qCeil(x / m_snapX) * m_snapX;
-            else m_x2 = qFloor(x / m_snapX) * m_snapX;
-
-            if (y > m_y1)
-                m_y2 = qCeil(y / m_snapY) * m_snapY;
-            else m_y2 = qFloor(y / m_snapY) * m_snapY;
+            auto currentTileX = qFloor(x / m_snapX);
+            auto currentTileY = qFloor(y / m_snapY);
+            if (currentTileX >= m_startTileX) {
+                m_x1 = m_startTileX * m_snapX;
+                m_x2 = (currentTileX + 1) * m_snapX;
+            } else {
+                m_x1 = (m_startTileX + 1) * m_snapX;
+                m_x2 = currentTileX * m_snapX;
+            }
+            if (currentTileY >= m_startTileY) {
+                m_y1 = m_startTileY * m_snapY;
+                m_y2 = (currentTileY + 1) * m_snapY;
+            } else {
+                m_y1 = (m_startTileY + 1) * m_snapY;
+                m_y2 = currentTileY * m_snapY;
+            }
         }
 
         void endSelection(float x, float y)


### PR DESCRIPTION
- Gani Editor: Added an Overwrite button when adding a sprite with an existing index.

- Tile Editor: Fixed tile selection not including starting tile position when dragging in reverse, resulting in the offset being wrong.