### PR TITLE
Added keyswap toggle for WASD/arrows to ganieditor

### DIFF
--- a/Forms/AniEditor/AniEditorWindow.ui
+++ b/Forms/AniEditor/AniEditorWindow.ui
@@ -73,6 +73,7 @@
    <addaction name="actionSetWorkingDirectory"/>
    <addaction name="separator"/>
    <addaction name="actionBackgroundColor"/>
+   <addaction name="actionSwapKeys"/>
    <addaction name="separator"/>
    <addaction name="actionCloseAll"/>
   </widget>
@@ -189,6 +190,27 @@
    </property>
    <property name="toolTip">
     <string>Set Background Color</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::MenuRole::NoRole</enum>
+   </property>
+  </action>
+  <action name="actionSwapKeys">
+   <property name="icon">
+    <iconset resource="../../Resources/MainWindow.qrc">
+     <normaloff>:/MainWindow/icons/tinycolor/icons8-change-16.png</normaloff>:/MainWindow/icons/tinycolor/icons8-change-16.png</iconset>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="iconText">
+    <string notr="true"/>
+   </property>
+   <property name="text">
+    <string notr="true"/>
+   </property>
+   <property name="toolTip">
+    <string>Swap WASD/Arrow Keys (WASD=Direction, Arrows=Move)</string>
    </property>
    <property name="menuRole">
     <enum>QAction::MenuRole::NoRole</enum>

--- a/src/AniEditor/AniEditor.cpp
+++ b/src/AniEditor/AniEditor.cpp
@@ -279,40 +279,16 @@ namespace TilesEditor
 		ui.yLineEdit->setValidator(new QDoubleValidator(-1000000000, 1000000000, 2, ui.yLineEdit));
 		setSpritePreviewZoomLevel(4);
 
-		auto downKeyShortcut = new QShortcut(this);
-		downKeyShortcut->setKey(Qt::Key_Down);
-		connect(downKeyShortcut, &QShortcut::activated, this, &AniEditor::downKeyPressed);
+		m_downKeyShortcut = new QShortcut(this);
+		m_upKeyShortcut = new QShortcut(this);
+		m_leftKeyShortcut = new QShortcut(this);
+		m_rightKeyShortcut = new QShortcut(this);
+		m_sKeyShortCut = new QShortcut(this);
+		m_aKeyShortCut = new QShortcut(this);
+		m_dKeyShortCut = new QShortcut(this);
+		m_wKeyShortCut = new QShortcut(this);
 
-		auto upKeyShortcut = new QShortcut(this);
-		upKeyShortcut->setKey(Qt::Key_Up);
-		connect(upKeyShortcut, &QShortcut::activated, this, &AniEditor::upKeyPressed);
-
-		auto leftKeyShortcut = new QShortcut(this);
-		leftKeyShortcut->setKey(Qt::Key_Left);
-		connect(leftKeyShortcut, &QShortcut::activated, this, &AniEditor::leftKeyPressed);
-
-		auto rightKeyShortcut = new QShortcut(this);
-		rightKeyShortcut->setKey(Qt::Key_Right);
-		connect(rightKeyShortcut, &QShortcut::activated, this, &AniEditor::rightKeyPressed);
-
-
-		//Using QShortcut instead of the built-in shortcut in QAbstractButton since that's
-		//Too slow with the key-repeat
-		auto sKeyShortCut = new QShortcut(this);
-		sKeyShortCut->setKey(Qt::Key_S);
-		connect(sKeyShortCut, &QShortcut::activated, ui.itemDownButton, &QAbstractButton::click);
-
-		auto aKeyShortCut = new QShortcut(this);
-		aKeyShortCut->setKey(Qt::Key_A);
-		connect(aKeyShortCut, &QShortcut::activated, ui.itemLeftButton, &QAbstractButton::click);
-
-		auto dKeyShortCut = new QShortcut(this);
-		dKeyShortCut->setKey(Qt::Key_D);
-		connect(dKeyShortCut, &QShortcut::activated, ui.itemRightButton, &QAbstractButton::click);
-
-		auto wKeyShortCut = new QShortcut(this);
-		wKeyShortCut->setKey(Qt::Key_W);
-		connect(wKeyShortCut, &QShortcut::activated, ui.itemUpButton, &QAbstractButton::click);
+		setupKeyShortcuts();
 
 		applySettings(settings);
 
@@ -950,6 +926,86 @@ namespace TilesEditor
 	void AniEditor::rightKeyPressed()
 	{
 		ui.directionComboBox->setCurrentIndex(3);
+	}
+
+	void AniEditor::setupKeyShortcuts()
+	{
+		if (m_keysSwapped)
+		{
+			// WASD = Direction, Arrows = Move
+			m_wKeyShortCut->setKey(Qt::Key_W);
+			m_wKeyShortCut->disconnect();
+			connect(m_wKeyShortCut, &QShortcut::activated, this, &AniEditor::upKeyPressed);
+
+			m_aKeyShortCut->setKey(Qt::Key_A);
+			m_aKeyShortCut->disconnect();
+			connect(m_aKeyShortCut, &QShortcut::activated, this, &AniEditor::leftKeyPressed);
+
+			m_sKeyShortCut->setKey(Qt::Key_S);
+			m_sKeyShortCut->disconnect();
+			connect(m_sKeyShortCut, &QShortcut::activated, this, &AniEditor::downKeyPressed);
+
+			m_dKeyShortCut->setKey(Qt::Key_D);
+			m_dKeyShortCut->disconnect();
+			connect(m_dKeyShortCut, &QShortcut::activated, this, &AniEditor::rightKeyPressed);
+
+			m_upKeyShortcut->setKey(Qt::Key_Up);
+			m_upKeyShortcut->disconnect();
+			connect(m_upKeyShortcut, &QShortcut::activated, ui.itemUpButton, &QAbstractButton::click);
+
+			m_leftKeyShortcut->setKey(Qt::Key_Left);
+			m_leftKeyShortcut->disconnect();
+			connect(m_leftKeyShortcut, &QShortcut::activated, ui.itemLeftButton, &QAbstractButton::click);
+
+			m_downKeyShortcut->setKey(Qt::Key_Down);
+			m_downKeyShortcut->disconnect();
+			connect(m_downKeyShortcut, &QShortcut::activated, ui.itemDownButton, &QAbstractButton::click);
+
+			m_rightKeyShortcut->setKey(Qt::Key_Right);
+			m_rightKeyShortcut->disconnect();
+			connect(m_rightKeyShortcut, &QShortcut::activated, ui.itemRightButton, &QAbstractButton::click);
+		}
+		else
+		{
+			// Arrows = Direction, WASD = Move (default)
+			m_upKeyShortcut->setKey(Qt::Key_Up);
+			m_upKeyShortcut->disconnect();
+			connect(m_upKeyShortcut, &QShortcut::activated, this, &AniEditor::upKeyPressed);
+
+			m_leftKeyShortcut->setKey(Qt::Key_Left);
+			m_leftKeyShortcut->disconnect();
+			connect(m_leftKeyShortcut, &QShortcut::activated, this, &AniEditor::leftKeyPressed);
+
+			m_downKeyShortcut->setKey(Qt::Key_Down);
+			m_downKeyShortcut->disconnect();
+			connect(m_downKeyShortcut, &QShortcut::activated, this, &AniEditor::downKeyPressed);
+
+			m_rightKeyShortcut->setKey(Qt::Key_Right);
+			m_rightKeyShortcut->disconnect();
+			connect(m_rightKeyShortcut, &QShortcut::activated, this, &AniEditor::rightKeyPressed);
+
+			m_wKeyShortCut->setKey(Qt::Key_W);
+			m_wKeyShortCut->disconnect();
+			connect(m_wKeyShortCut, &QShortcut::activated, ui.itemUpButton, &QAbstractButton::click);
+
+			m_aKeyShortCut->setKey(Qt::Key_A);
+			m_aKeyShortCut->disconnect();
+			connect(m_aKeyShortCut, &QShortcut::activated, ui.itemLeftButton, &QAbstractButton::click);
+
+			m_sKeyShortCut->setKey(Qt::Key_S);
+			m_sKeyShortCut->disconnect();
+			connect(m_sKeyShortCut, &QShortcut::activated, ui.itemDownButton, &QAbstractButton::click);
+
+			m_dKeyShortCut->setKey(Qt::Key_D);
+			m_dKeyShortCut->disconnect();
+			connect(m_dKeyShortCut, &QShortcut::activated, ui.itemRightButton, &QAbstractButton::click);
+		}
+	}
+
+	void AniEditor::setKeysSwapped(bool swapped)
+	{
+		m_keysSwapped = swapped;
+		setupKeyShortcuts();
 	}
 
 	void AniEditor::updateItemSettings()

--- a/src/AniEditor/AniEditor.h
+++ b/src/AniEditor/AniEditor.h
@@ -154,8 +154,18 @@ namespace TilesEditor
 		QPixmap m_downRightPix;
 		
 		QUndoStack m_undoStack;
+		bool m_keysSwapped = false;
+		QShortcut* m_downKeyShortcut = nullptr;
+		QShortcut* m_upKeyShortcut = nullptr;
+		QShortcut* m_leftKeyShortcut = nullptr;
+		QShortcut* m_rightKeyShortcut = nullptr;
+		QShortcut* m_sKeyShortCut = nullptr;
+		QShortcut* m_aKeyShortCut = nullptr;
+		QShortcut* m_dKeyShortCut = nullptr;
+		QShortcut* m_wKeyShortCut = nullptr;
 
 		void updateFrame();
+		void setupKeyShortcuts();
 		qsizetype addFramePieceToItems(Ani::Frame::FramePiece * piece);
 		
 		void deleteSelectedFrame();
@@ -209,6 +219,7 @@ namespace TilesEditor
 		void removeFrame(qsizetype index) override;
 		void insertFrame(qsizetype index, Ani::Frame* frame) override;
 		void setSelectedPieces(const QList<Ani::Frame::FramePiece*>& pieces) override;
+		void setKeysSwapped(bool swapped);
 	};
 }
 

--- a/src/AniEditor/AniEditorWindow.cpp
+++ b/src/AniEditor/AniEditorWindow.cpp
@@ -22,6 +22,7 @@ namespace TilesEditor
 		connect(ui.actionSaveAll, &QAction::triggered, this, &AniEditorWindow::actionSaveAllClicked);
 		connect(ui.actionCloseAll, &QAction::triggered, this, &AniEditorWindow::actionCloseAllClicked);
 		connect(ui.actionBackgroundColor, &QAction::triggered, this, &AniEditorWindow::actionSetBackgroundColour);
+		connect(ui.actionSwapKeys, &QAction::toggled, this, &AniEditorWindow::actionSwapKeysToggled);
 		connect(ui.actionSetWorkingDirectory, &QAction::triggered, this, &AniEditorWindow::actionSetWorkingDirectoryClicked);
 		connect(ui.tabWidgetMain, &QTabWidget::tabCloseRequested, this, &AniEditorWindow::tabClose);
 
@@ -74,6 +75,10 @@ namespace TilesEditor
 		if (m_settings.contains("GaniEditor/BackColor"))
 			m_backgroundColor = QColor::fromString(m_settings.value("GaniEditor/BackColor").toString());
 
+		if (m_settings.contains("GaniEditor/KeysSwapped"))
+			m_keysSwapped = m_settings.value("GaniEditor/KeysSwapped").toBool();
+		ui.actionSwapKeys->setChecked(m_keysSwapped);
+
 	}
 
 	void AniEditorWindow::actionNewClicked(bool checked)
@@ -82,6 +87,7 @@ namespace TilesEditor
 
 		auto editor = new AniEditor("", m_resourceManager, m_settings, currentEditorTab);
 		editor->setBackgroundColour(m_backgroundColor);
+		editor->setKeysSwapped(m_keysSwapped);
 
 		connect(editor, &AniEditor::changeTabText, this, &AniEditorWindow::changeTabText);
 		connect(editor, &AniEditor::setStatusText, this, &AniEditorWindow::setStatusText);
@@ -143,6 +149,18 @@ namespace TilesEditor
 		for (int i = ui.tabWidgetMain->count() - 1; i >= 0; --i)
 		{
 			closeTabIndex(i);
+		}
+	}
+
+	void AniEditorWindow::actionSwapKeysToggled(bool checked)
+	{
+		m_keysSwapped = checked;
+		m_settings.setValue("GaniEditor/KeysSwapped", checked);
+		for (int i = 0; i < ui.tabWidgetMain->count(); ++i)
+		{
+			auto editor = static_cast<AniEditor*>(ui.tabWidgetMain->widget(i));
+			if (editor)
+				editor->setKeysSwapped(checked);
 		}
 	}
 
@@ -270,6 +288,7 @@ namespace TilesEditor
 		auto currentEditorTab = static_cast<AniEditor*>(ui.tabWidgetMain->currentWidget());
 		auto retval = new AniEditor(fi.fileName(), m_resourceManager, m_settings, currentEditorTab);
 		retval->setBackgroundColour(m_backgroundColor);
+		retval->setKeysSwapped(m_keysSwapped);
 		connect(retval, &AniEditor::changeTabText, this, &AniEditorWindow::changeTabText);
 		connect(retval, &AniEditor::setStatusText, this, &AniEditorWindow::setStatusText);
 

--- a/src/AniEditor/AniEditorWindow.h
+++ b/src/AniEditor/AniEditorWindow.h
@@ -23,6 +23,7 @@ namespace TilesEditor
 		void actionSaveAllClicked(bool checked);
 		void actionCloseAllClicked(bool checked);
 		void actionSetBackgroundColour(bool checked);
+		void actionSwapKeysToggled(bool checked);
 
 		void actionSetWorkingDirectoryClicked(bool checked);
 		void tabClose(int index);
@@ -50,6 +51,7 @@ namespace TilesEditor
 		QSettings& m_settings;
 		QColor m_backgroundColor = QColorConstants::DarkGreen;
 		ResourceManagerFileSystem* m_resourceManager;
+		bool m_keysSwapped = false;
 
 		QMenu m_menuThemes;
 		QActionGroup* m_menuThemesGroup;


### PR DESCRIPTION
Added a button to the GaniEditor that allows swapping the functionality of WASD/arrows so you can move sprites with the arrow keys and change the direction with wasd.

<img width="125" height="94" alt="image" src="https://github.com/user-attachments/assets/07edac58-e5ed-472f-8f86-9c079be915a5" />
